### PR TITLE
Replace canow's ts-proto package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@canow-co/ledger-sdk",
-  "version": "3.2.0",
+  "version": "3.2.0-canow.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@canow-co/ledger-sdk",
-      "version": "3.2.0",
+      "version": "3.2.0-canow.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@canow-co/ts-proto": "^3.1.1",
+        "@canow-co/canow-proto": "^2.0.1-canow.2",
         "@cosmjs/amino": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",
         "@cosmjs/math": "^0.29.5",
@@ -651,11 +651,10 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@canow-co/ts-proto": {
-      "version": "3.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@canow-co/ts-proto/3.1.1/36e992d43cf6cb5cfc14d3ae06176fbb73fd46bf",
-      "integrity": "sha512-5GbyxbXmj3x9xV4L3TWCF7l+9Hz0jkwKyNTTxU1gMw1HFh3K0QFmSqk73BZ0/s9+CvOiVdhJj4rCF7VIHl2ggQ==",
-      "license": "Apache-2.0",
+    "node_modules/@canow-co/canow-proto": {
+      "version": "2.0.1-canow.2",
+      "resolved": "https://npm.pkg.github.com/download/@canow-co/canow-proto/2.0.1-canow.2/ee3a7bddf31587f0a6891932ed4fd0b6ac9bc92a",
+      "integrity": "sha512-ccp9S2TMl/jsVQGCD1cAXbBWBwboIgs0I+rSAKVLCmbVXFRK9g4eisHcYURHKjNPTyyZEghRp5OPo2+aaEwmIA==",
       "dependencies": {
         "long": "^5.2.1",
         "protobufjs": "^7.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canow-co/ledger-sdk",
-  "version": "3.2.0",
+  "version": "3.2.0-canow.6",
   "description": "A TypeScript SDK built with CosmJS to interact with cheqd network ledger",
   "license": "Apache-2.0",
   "author": "Cheqd Foundation Limited (https://github.com/cheqd)",
@@ -51,7 +51,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@canow-co/ts-proto": "^3.1.1",
+    "@canow-co/canow-proto": "^2.0.1-canow.2",
     "@cosmjs/amino": "^0.29.5",
     "@cosmjs/encoding": "^0.29.5",
     "@cosmjs/math": "^0.29.5",

--- a/src/modules/resource.ts
+++ b/src/modules/resource.ts
@@ -22,17 +22,17 @@ import {
 	QueryCollectionResourcesResponse,
 	ResourceWithMetadata,
 	protobufPackage
-} from "@canow-co/ts-proto/cheqd/resource/v2/index.js"
+} from "@canow-co/canow-proto/dist/cheqd/resource/v2"
 import {
 	DeliverTxResponse,
 	QueryClient,
 	createPagination,
 	createProtobufRpcClient
 } from "@cosmjs/stargate"
-import { SignInfo } from "@canow-co/ts-proto/cheqd/did/v2/index.js";
+import { SignInfo } from "@canow-co/canow-proto/dist/cheqd/did/v2";
 import { fileTypeFromBuffer } from "file-type";
 import { assert } from '@cosmjs/utils';
-import { PageRequest } from '@canow-co/ts-proto/cosmos/base/query/v1beta1/pagination.js';
+import { PageRequest } from '@canow-co/canow-proto/dist/cosmos/base/query/v1beta1/pagination.js';
 import { CheqdQuerier } from '../querier.js';
 
 export const defaultResourceExtensionKey = 'resource' as const

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -22,7 +22,7 @@ import {
 	MsgUpdateDidDocPayload,
 	MsgDeactivateDidDocPayload,
 	VerificationMethod 
-} from '@canow-co/ts-proto/cheqd/did/v2/index.js';
+} from '@canow-co/canow-proto/dist/cheqd/did/v2';
 import {
 	DidStdFee,
 	ISignInputs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import {
     Service as ProtobufService, 
     VerificationMethod as ProtobufVerificationMethod
-} from "@canow-co/ts-proto/cheqd/did/v2/index.js"
+} from "@canow-co/canow-proto/dist/cheqd/did/v2"
 import { CheqdSDK } from "./index.js"
 import { Coin } from "@cosmjs/proto-signing"
 import { Signer } from "did-jwt"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,7 @@ import {
     VerificationMethod as ProtoVerificationMethod,
     Service as ProtoService,
     VerificationRelationship,
-} from "@canow-co/ts-proto/cheqd/did/v2/index.js"
+} from "@canow-co/canow-proto/dist/cheqd/did/v2/index.js"
 
 export type TImportableEd25519Key = {
     publicKeyHex: string

--- a/tests/modules/resource.test.ts
+++ b/tests/modules/resource.test.ts
@@ -35,7 +35,7 @@ import {
     AlternativeUri,
     Metadata,
     MsgCreateResourcePayload
-} from '@canow-co/ts-proto/cheqd/resource/v2';
+} from '@canow-co/canow-proto/dist/cheqd/resource/v2';
 import { v4 } from "uuid"
 import { CheqdQuerier } from "../../src/querier"
 import {

--- a/tests/signer.test.ts
+++ b/tests/signer.test.ts
@@ -2,7 +2,7 @@ import {
     MsgCreateDidDoc,
     MsgCreateDidDocPayload,
     VerificationMethod
-} from "@canow-co/ts-proto/cheqd/did/v2"
+} from "@canow-co/canow-proto/dist/cheqd/did/v2"
 import {
     DirectSecp256k1HdWallet,
     Registry


### PR DESCRIPTION
- Used canow's proto package without ESM exports
- Conversion of the DIDDocument to proto format extracted into separate method