### PR TITLE
[DDS-508] Workaround for DID controller bug in AFJ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canow-co/ledger-sdk",
-  "version": "3.4.0-canow.5",
+  "version": "3.4.0-canow.6",
   "description": "A TypeScript SDK built with CosmJS to interact with cheqd network ledger",
   "license": "Apache-2.0",
   "author": "Cheqd Foundation Limited (https://github.com/cheqd)",

--- a/src/modules/did.ts
+++ b/src/modules/did.ts
@@ -445,6 +445,14 @@ export class DIDModule extends AbstractCheqdSDKModule {
 	}
 
 	static async toSpecCompliantPayload(protobufDidDocument: DidDoc): Promise<DIDDocument> {
+		// TODO: We use an array of one string instead of just a string as a value for `controller` field of a specification-compliant DIDDocument
+		// until https://github.com/hyperledger/aries-framework-javascript/issues/1643 is fixed.
+		// After the specified issue is fixed, replace this statement with the commented out statement below.
+		const controller = protobufDidDocument.controller.length > 0 ? protobufDidDocument.controller : undefined
+		// const controller = protobufDidDocument.controller.length > 1
+		// 	? protobufDidDocument.controller
+		// 	: protobufDidDocument.controller[0]
+
 		const verificationMethod = protobufDidDocument.verificationMethod.map(vm => {
 			return fromProtoVerificationMethod(protobufDidDocument.context, vm)
 		})
@@ -467,7 +475,7 @@ export class DIDModule extends AbstractCheqdSDKModule {
 		const specCompliant = {
 			'@context': context,
 			id: protobufDidDocument.id,
-			controller: protobufDidDocument.controller.length === 1 ? protobufDidDocument.controller[0] : protobufDidDocument.controller,
+			controller: controller,
 			verificationMethod: verificationMethod,
 			authentication: fromVerificationRelationships(context, protobufDidDocument.authentication),
 			assertionMethod: fromVerificationRelationships(context, protobufDidDocument.assertionMethod),


### PR DESCRIPTION
- Made a workaround for the bug with the type of controller field of DidDocumentOptions type from AFJ.
- Bumped package version.