### PR TITLE
[DDS-508] Workaround for DID controller bug in AFJ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canow-co/ledger-sdk",
-  "version": "3.4.0-canow.6",
+  "version": "3.4.0-canow.7",
   "description": "A TypeScript SDK built with CosmJS to interact with cheqd network ledger",
   "license": "Apache-2.0",
   "author": "Cheqd Foundation Limited (https://github.com/cheqd)",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,9 +181,13 @@ export function createDidPayload(verificationMethods: VerificationMethod[], veri
         throw new Error('No verification keys provided')
 
     const did = verificationKeys[0].didUrl
+    
+    // TODO: We use an array of one string instead of just a string as a value for `controller` field of a specification-compliant DIDDocument
+    // until https://github.com/hyperledger/aries-framework-javascript/issues/1643 is fixed.
+    // After the specified issue is fixed, replace the controller field value in the statement below with just `controller`.
     return {
             id: did,
-            controller,
+            controller: controller !== undefined ? [controller] : undefined,
             verificationMethod: verificationMethods,
             authentication: verificationKeys.map(key => key.keyId)
     } as DIDDocument


### PR DESCRIPTION
- Made a workaround for the bug with the type of controller field of DidDocumentOptions type from AFJ.
- Bumped package version.