### PR TITLE
[DDS-508] Removed workaround for controller issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@canow-co/ledger-sdk",
-  "version": "3.4.0-canow.3",
+  "version": "3.4.0-canow.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@canow-co/ledger-sdk",
-      "version": "3.4.0-canow.3",
+      "version": "3.4.0-canow.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@canow-co/canow-proto": "^2.0.1-canow.2",
+        "@canow-co/canow-proto": "2.0.1-canow.2",
         "@cosmjs/amino": "^0.29.5",
         "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canow-co/ledger-sdk",
-  "version": "3.4.0-canow.7",
+  "version": "3.4.0-canow.8",
   "description": "A TypeScript SDK built with CosmJS to interact with cheqd network ledger",
   "license": "Apache-2.0",
   "author": "Cheqd Foundation Limited (https://github.com/cheqd)",
@@ -46,15 +46,15 @@
     "README.md"
   ],
   "dependencies": {
-    "@canow-co/canow-proto": "^2.0.1-canow.2",
+    "@canow-co/canow-proto": "2.0.1-canow.2",
     "@cosmjs/amino": "^0.29.5",
+    "@cosmjs/crypto": "^0.29.5",
     "@cosmjs/encoding": "^0.29.5",
     "@cosmjs/math": "^0.29.5",
     "@cosmjs/proto-signing": "^0.29.5",
     "@cosmjs/stargate": "^0.29.5",
     "@cosmjs/tendermint-rpc": "^0.29.5",
     "@cosmjs/utils": "^0.29.5",
-    "@cosmjs/crypto": "^0.29.5",
     "@stablelib/ed25519": "^1.0.3",
     "cosmjs-types": "^0.5.2",
     "did-jwt": "^6.11.6",

--- a/src/modules/did.ts
+++ b/src/modules/did.ts
@@ -445,13 +445,9 @@ export class DIDModule extends AbstractCheqdSDKModule {
 	}
 
 	static async toSpecCompliantPayload(protobufDidDocument: DidDoc): Promise<DIDDocument> {
-		// TODO: We use an array of one string instead of just a string as a value for `controller` field of a specification-compliant DIDDocument
-		// until https://github.com/hyperledger/aries-framework-javascript/issues/1643 is fixed.
-		// After the specified issue is fixed, replace this statement with the commented out statement below.
-		const controller = protobufDidDocument.controller.length > 0 ? protobufDidDocument.controller : undefined
-		// const controller = protobufDidDocument.controller.length > 1
-		// 	? protobufDidDocument.controller
-		// 	: protobufDidDocument.controller[0]
+		const controller = protobufDidDocument.controller.length > 1
+			? protobufDidDocument.controller
+			: protobufDidDocument.controller.at(0)
 
 		const verificationMethod = protobufDidDocument.verificationMethod.map(vm => {
 			return fromProtoVerificationMethod(protobufDidDocument.context, vm)
@@ -557,13 +553,13 @@ export class DIDModule extends AbstractCheqdSDKModule {
 			context: <string[]>didPayload?.['@context'],
 			id: didPayload.id,
 			controller: controller,
-			verificationMethod: protobufVerificationMethod,
+			verificationMethod: protobufVerificationMethod!,
 			authentication: toVerificationRelationships(didPayload.authentication),
 			assertionMethod: toVerificationRelationships(didPayload.assertionMethod),
 			capabilityInvocation: toVerificationRelationships(didPayload.capabilityInvocation),
 			capabilityDelegation: toVerificationRelationships(didPayload.capabilityDelegation),
 			keyAgreement: toVerificationRelationships(didPayload.keyAgreement),
-			service: protobufService,
+			service: protobufService ?? [],
 			alsoKnownAs: <string[]>didPayload.alsoKnownAs,
 			versionId: versionId
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -182,15 +182,12 @@ export function createDidPayload(verificationMethods: VerificationMethod[], veri
 
     const did = verificationKeys[0].didUrl
     
-    // TODO: We use an array of one string instead of just a string as a value for `controller` field of a specification-compliant DIDDocument
-    // until https://github.com/hyperledger/aries-framework-javascript/issues/1643 is fixed.
-    // After the specified issue is fixed, replace the controller field value in the statement below with just `controller`.
     return {
-            id: did,
-            controller: controller !== undefined ? [controller] : undefined,
-            verificationMethod: verificationMethods,
-            authentication: verificationKeys.map(key => key.keyId)
-    } as DIDDocument
+        id: did,
+        controller,
+        verificationMethod: verificationMethods,
+        authentication: verificationKeys.map(key => key.keyId)
+    }
 }
 
 export function validateSpecCompliantPayload(didDocument: DIDDocument): SpecValidationResult {


### PR DESCRIPTION
- Removed the workaround for the controller field issue in AFJ because it had been moved to type conversion helpers in @canow-co/afj-canow package.
- Pinned @canow-co/canow-proto package version.
- Made some minor corrections.
- Bumped package version.